### PR TITLE
Add logic to deal with ipython magic commands

### DIFF
--- a/ipython_notebook_config.txt
+++ b/ipython_notebook_config.txt
@@ -81,7 +81,12 @@ def write_notebook_data_to_py(notebook_data, out_file_path):
                 output.write('\n')
                 for item in cell['source']:
                     if cell['cell_type']=='code':
-                        output.write(item)
+                        # Comment out ipython magic commands like "%matplotlib inline"
+                        if item[0] == '%':
+                            output.write('# ')
+                            output.write(item)
+                        else:
+                            output.write(item)
                     else:
                         output.write('# ')
                         output.write(item)

--- a/notebook_v4_to_py.py
+++ b/notebook_v4_to_py.py
@@ -87,7 +87,12 @@ def write_notebook_data_to_py(notebook_data, out_file_path):
                 output.write('\n')
                 for item in cell['source']:
                     if cell['cell_type']=='code':
-                        output.write(item)
+                        # Comment out ipython magic commands like "%matplotlib inline"
+                        if item[0] == '%':
+                            output.write('# ')
+                            output.write(item)
+                        else:
+                            output.write(item)
                     else:
                         output.write('# ')
                         output.write(item)

--- a/py_to_notebook_v4.py
+++ b/py_to_notebook_v4.py
@@ -112,7 +112,11 @@ def build_notebook_cells(lines):
             else:
                 source.append(line)
         elif current_cell=='code':
-            source.append(line)
+            # Remove comments for ipython magic commands like "%matplotlib inline"
+            if line[0:3] == '# %':
+                source.append(line[2:])
+            else:
+                source.append(line)
 
     last_cell = True
     outputcells = close_cell(current_cell)


### PR DESCRIPTION
iPython magic commands like `%matplotlib inline` are useful inside of an Jupyter notebook but raise errors when run in a Python script. These two commits add logic to comment out magic commands starting with `%` when converting from `.ipynb` to `.py`. Magic commands are uncommented when converting back to `.ipynb`. Let me know what you think! 