### PR TITLE
Move log messages to jupyter logger

### DIFF
--- a/ipython_notebook_config.txt
+++ b/ipython_notebook_config.txt
@@ -43,9 +43,12 @@
 #In jupyter_notebook_config.py, we insert the following Python code:
 
 from __future__ import print_function
+import logging
 import sys
 import json
 import os
+
+logger = logging.getLogger('tornado')
 
 if (sys.version_info[0] < 3):
     reload(sys)
@@ -71,7 +74,7 @@ def write_notebook_data_to_py(notebook_data, out_file_path):
         try:
             cells = notebook_data['cells']
         except KeyError:
-            print ("Nbformat is " + str(notebook_data['nbformat']) + ", try the old converter script.")
+            logger.info("Nbformat is " + str(notebook_data['nbformat']) + ", try the old converter script.")
             return
 
         for cell in cells:
@@ -97,7 +100,7 @@ def post_save(model, os_path, contents_manager):
     output_file_path = construct_output_py_file_path(os_path, skip_if_exists=False)
     notebook_data = get_notebook_data(os_path)
     write_notebook_data_to_py(notebook_data, output_file_path)
-    print (output_file_path, "was successfully saved")
+    logger.info(output_file_path + " was successfully saved")
 
 c = get_config()
 c.FileContentsManager.post_save_hook = post_save


### PR DESCRIPTION
Jupyter basic operations on notebooks are done on its tornado logger, using
stdout instead can cause the saving process to fail if stdout channel
was closed (in the case of an ssh connection for instance). In that case
the script would crash on the print() function.